### PR TITLE
Remove problematic usage of fs and path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "javascript.format.enable": false
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,4 @@
-import { realpathSync, existsSync } from 'fs';
-import { extname, resolve, normalize } from 'path';
-import { sync as nodeResolveSync, isCore } from 'resolve';
+import { extname, normalize } from 'path';
 import { createFilter } from 'rollup-pluginutils';
 import { peerDependencies } from '../package.json';
 import {
@@ -21,39 +19,8 @@ export default function commonjs(options = {}) {
 	const filter = createFilter(options.include, options.exclude);
 	const ignoreGlobal = options.ignoreGlobal;
 
-	const customNamedExports = {};
-	if (options.namedExports) {
-		Object.keys(options.namedExports).forEach(id => {
-			let resolveId = id;
-			let resolvedId;
-
-			if (isCore(id)) {
-				// resolve will not find npm modules with the same name as
-				// core modules without a trailing slash. Since core modules
-				// must be external, we can assume any core modules defined
-				// here are npm modules by that name.
-				resolveId += '/';
-			}
-
-			try {
-				resolvedId = nodeResolveSync(resolveId, { basedir: process.cwd() });
-			} catch (err) {
-				resolvedId = resolve(id);
-			}
-
-			// Note: customNamedExport's keys must be normalized file paths.
-			// resolve and nodeResolveSync both return normalized file paths
-			// so no additional normalization is necessary.
-			customNamedExports[resolvedId] = options.namedExports[id];
-
-			if (existsSync(resolvedId)) {
-				const realpath = realpathSync(resolvedId);
-				if (realpath !== resolvedId) {
-					customNamedExports[realpath] = options.namedExports[id];
-				}
-			}
-		});
-	}
+  const customNamedExports = {};
+  // ESY: Disable namedExports option to avoid fs.
 
 	const esModulesWithoutDefaultExport = new Set();
 	const esModulesWithDefaultExport = new Set();


### PR DESCRIPTION
* All use of `fs` is removed
* Use of `path.resolve` is removed, since it does file access access. Others like `path.sep`, `path.basename`, etc. are left. These will have to be polyfilled.

Unfortunately, this breaks a LOT of tests due to the assumption introduced in `src/resolve-id.js`: All IDs must be resolved by plugins and cannot rely on the default rollup behavior.